### PR TITLE
Support exponential backoff on 429 and error responses

### DIFF
--- a/float_api/float_api.py
+++ b/float_api/float_api.py
@@ -27,6 +27,15 @@ class FloatAPI():
     # The session to use for all requests
     self.session = requests.Session()
 
+    retry_strategy = requests.packages.urllib3.util.retry.Retry(
+      total=10,
+      backoff_factor=2,
+      status_forcelist=[429, 500, 502, 503, 504],
+      method_whitelist=["GET", "POST", "PATCH", "DELETE"]
+    )
+    adapter = requests.adapters.HTTPAdapter(max_retries=retry_strategy)
+    self.session.mount("https://", adapter)
+
     # Headers to send with every request
     self.headers = {
       "Authorization": "Bearer {}".format(access_token),
@@ -93,7 +102,7 @@ class FloatAPI():
     # Python does not allow '-' in variable names, but Float
     # parameter is called 'per-page'
     if 'per_page' in params.keys():
-      params['per-page'] = params.pop('per_page') 
+      params['per-page'] = params.pop('per_page')
 
     # Set default objects per page
     if 'per-page' not in params:
@@ -125,7 +134,7 @@ class FloatAPI():
       list_to_return += l
 
       # Exit loop if we are on the last page of results
-      if int(r.headers['X-Pagination-Current-Page']) >= int(r.headers['X-Pagination-Page-Count']): 
+      if int(r.headers['X-Pagination-Current-Page']) >= int(r.headers['X-Pagination-Page-Count']):
         break
 
       # Next page
@@ -184,7 +193,7 @@ class FloatAPI():
 
 
   ## GET ##
-  
+
   def get_account(self, account_id):
 
     raise NotImplementedError('Not possible with API')
@@ -443,7 +452,7 @@ class FloatAPI():
 
     if 'name' not in kwargs.keys():
       raise KeyError('Missing required key \'name\'')
-    
+
     return self._post('people', kwargs)
 
 
@@ -520,7 +529,7 @@ class FloatAPI():
 
 
   ## UPDATE ##
-  
+
   def update_account(self, **kwargs):
 
     raise NotImplementedError('Not possible with API')


### PR DESCRIPTION
As per the documentation, Float will return a 429 response code when the client is being rate limited.

This adds support to handle these conditions transparently.
